### PR TITLE
add plugin_cache_dir, make more visible note about direct{}

### DIFF
--- a/PAXOS_INSTALL.md
+++ b/PAXOS_INSTALL.md
@@ -35,23 +35,28 @@ cp $GOPATH/bin/terraform-provider-aws ~/.terraform.d/plugins/registry.terraform.
   + [^How to override a provider with a local version]
     ```sh
     # @File: ~/.terraformrc
+    
+    # define path to downloaded / cached plugins (default)
+    plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"
+    
     provider_installation {
       # Use /home/developer/tmp/terraform-null as an overridden package directory
       # for the hashicorp/null provider. This disables the version and checksum
       # verifications for this provider and forces Terraform to look for the
       # null provider plugin in the given directory.
       filesystem_mirror {
-        path    = "/Users/mnichols/.terraform.d/plugins"
-        include = ["hashicorp/aws"]
+        path    = "$HOME/.terraform.d/plugins"
+        include = ["hashicorp/aws","hashicorp/*"]
       }
 
       #dev_overrides {
-      #  "hashicorp/aws" = "/Users/mnichols/go/bin/terraform-provider-aws"
+      #  "hashicorp/aws" = "$HOME/go/bin/terraform-provider-aws"
       #}
-    
+
+      # NOTE: If you omit `direct{}` block, Terraform will _only_ search the dev_overrides block
+      #       and so no other providers will be available.
       # For all other providers, install them directly from their origin provider
-      # registries as normal. If you omit this, Terraform will _only_ use
-      # the dev_overrides block, and so no other providers will be available.
+      # registries as normal.
       direct {
         exclude = ["registry.terraform.io/hashicorp/aws"]
       }


### PR DESCRIPTION
include example value for `plugin_cache_dir`
highlight note about `direct{}` block

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
